### PR TITLE
Automatic installation of Volta

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,16 @@
+[interpreters.sh]
+command = "C:\\msys64\\usr\\bin\\bash.exe"
+[data.volta]
+{{ if eq .chezmoi.os "windows" }}
+variant = "windows"
+{{ else if eq .chezmoi.os "linux" }}
+variant = "linux-openssl-1.1" # FIXME: Should detect OpenSSL 1.0, 1.1 and RHEL variant: https://git.io/JP7SU
+{{ else if eq .chezmoi.os "darwin" }}
+variant = "darwin{{ if eq .chezmoi.arch "arm64" }}-aarch64{{ end }}"
+{{ end }}
+
+{{ if eq .chezmoi.os "windows" }}
+ext = ".zip"
+{{ else }}
+ext = ".tar.gz"
+{{ end }}

--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -19,3 +19,8 @@
     type = "file"
     url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
     refreshPeriod = "168h"
+
+[".volta"]
+    type = "archive"
+    url = 'https://github.com/volta-cli/volta/releases/latest/download/volta-{{- output "curl" "https://volta.sh/latest-version" | trim -}}-{{ .volta.variant }}{{ .volta.ext }}'
+    refreshPeriod = "168h"


### PR DESCRIPTION
- [x] Download
- [ ] Put .volta into PATH
- [ ] Add to Windows global PATH [as described here](https://ziglearn.org/#installation)
- [ ] Set VOLTA_HOME
- [ ] Find a way to ignore $VOLTA_HOME/bin

https://docs.volta.sh/advanced/installers

## Optional
- Figure out OpenSSL version in Linux